### PR TITLE
Bootstrap 4 styling changes

### DIFF
--- a/css/searchPanes.bootstrap4.scss
+++ b/css/searchPanes.bootstrap4.scss
@@ -8,7 +8,7 @@ div.dtsp-searchPanes{
     align-items: stretch;
     clear: both;
     button.btn{
-        margin: 1px;
+        margin: 0;
     }
 
     button.dtsp-clearAll{
@@ -49,16 +49,12 @@ div.dtsp-searchPane {
     }
     div.btn-group{
         padding: 0px;
-    
-        button.btn{
-            margin: 0;
-            height: 40px;
-        }
     }
     margin: 5px;
     div.dtsp-topRow{
         padding: 0px !important;
-        margin: 0px !important;    
+        margin: 0px;    
+	margin-bottom: 0.5rem;
         div.dtsp-subRows{
             padding: 0px !important;
             text-align: right;
@@ -81,7 +77,6 @@ div.dtsp-searchPane {
     }
 
     .input-group {
-        height: 40px !important;
         padding: 0px !important;
 
         .input-group-append{
@@ -148,13 +143,16 @@ div.dtsp-panes {
     
     div.dtsp-titleRow {
         padding-bottom: 10px;
+	padding-left: 20px;
+        padding-right: 20px;
     }
 
 	div.dtsp-title {
 		float: left;
-		margin: 20px;
 		margin-bottom: 0px;
 		margin-top: 10px;
+		padding-left: 0;
+		padding-right: 0;
 	}
 
 	button.dtsp-clearAll{

--- a/src/searchPanes.bootstrap4.ts
+++ b/src/searchPanes.bootstrap4.ts
@@ -59,10 +59,10 @@ $.extend(true, DataTable.SearchPane.classes, {
 });
 
 $.extend(true, DataTable.SearchPanes.classes, {
-	clearAll: 'dtsp-clearAll col-1 btn btn-light',
+	clearAll: 'dtsp-clearAll col-auto btn btn-light',
 	container: 'dtsp-searchPanes',
 	panes: 'dtsp-panes dtsp-container',
-	title: 'dtsp-title col-10',
+	title: 'dtsp-title col',
 	titleRow: 'dtsp-titleRow row',
 });
 


### PR DESCRIPTION
There a couple of small issues (IMO) regarding the bootstrap 4 integration and here are the edits that I had to do to make it look fine.

### Styling changes
1. If looking closely at the example page with bootstrap 4 styling, we can see the search button is slightly off in the "input-group", removing this margin resolves this issue
2. The height of the inputs in bootstrap 4 give a total of 38px, not 40px. I removed the hardcoded heights so that they follow standard bootstrap heights

### Html (classes) changes
3. On smaller screens, the top row really doesn't look good, see the example page https://datatables.net/extensions/searchpanes/examples/styling/bootstrap4.html and make it smaller, the button text overflows and looks really bad. The solution for this is not in the css file edited here but in a modification to the classes applied to the elements. 
![image](https://user-images.githubusercontent.com/1885400/74753697-802b6900-523e-11ea-9c5e-05aa3978c90e.png)

The solution I found is the following : 
- For the `dtsp-title` element, it would be preferable to use the `col` class instead of `col-10`, which will let it take as much room as possible, without having a "hard-coded" width. 
- For the `dtsp-clearAll` element (the button), it would be better to use `col-auto` instead of `col-1` so that it can expand as required and not overflow like in the example page

I have tested the changes by manually editing the css file (not the scss file) so I could provide a fiddle where we can see the difference if required, but it would be better if a new build was done with the changes in the scss above and tried this way to ensure I didn't mess the chnages when converting from the end css file to the source scss file (shouldn't be the case, but we can never be 100% sure before testing :) )

The result looks like this (tbn, I also removed the dtsp-columns-x class in this example as I prefer having flexbox working its magic rather than limiting the width of the panes to a non responsive width):
![image](https://user-images.githubusercontent.com/1885400/74755297-f4ffa280-5240-11ea-8bbc-6f27703d1312.png)

