### PR TITLE
Add new option to overwrite general stateSave

### DIFF
--- a/src/searchPane.ts
+++ b/src/searchPane.ts
@@ -61,6 +61,7 @@ export default class SearchPane {
 			type: 'type'
 		},
 		preSelect: [],
+		stateSave: true,
 		threshold: 0.6,
 		viewTotal: false,
 	};
@@ -707,7 +708,7 @@ export default class SearchPane {
 				scrollY: '200px',
 				scroller: haveScroller ? true : false,
 				select: true,
-				stateSave: table.settings()[0].oFeatures.bStateSave ? true : false,
+				stateSave: (table.settings()[0].oFeatures.bStateSave && c.stateSave) ? true : false,
 			},
 			this.c.dtOpts, colOpts !== undefined ? colOpts.dtOpts : {},
 			(this.customPaneSettings !== null && this.customPaneSettings.dtOpts !== undefined)

--- a/src/searchPane.ts
+++ b/src/searchPane.ts
@@ -708,7 +708,7 @@ export default class SearchPane {
 				scrollY: '200px',
 				scroller: haveScroller ? true : false,
 				select: true,
-				stateSave: (table.settings()[0].oFeatures.bStateSave && c.stateSave) ? true : false,
+				stateSave: (table.settings()[0].oFeatures.bStateSave && this.c.stateSave) ? true : false,
 			},
 			this.c.dtOpts, colOpts !== undefined ? colOpts.dtOpts : {},
 			(this.customPaneSettings !== null && this.customPaneSettings.dtOpts !== undefined)


### PR DESCRIPTION
Adding a new default option (set to true to respect current behavior) to let the users define a specific `stateSave` setting for the `searchPanes` extension instead of only relying on the global `stateSave` option, a little bit like what is done with certain third-party datatables plugins (checkboxes)

