### PR TITLE
Add title to hidden text with ellipsis

### DIFF
--- a/src/searchPane.ts
+++ b/src/searchPane.ts
@@ -677,7 +677,7 @@ export default class SearchPane {
 								displayMessage = '<span class="' + this.classes.name + '">' + data + '</span>' + pill;
 							}
 							else if (data.length > this.c.dataLength) {
-								displayMessage = '<span class="' + this.classes.name + '">'
+								displayMessage = '<span title="' + data + '" class="' + _this.classes.name + '">'
 												+ data.substr(0, this.c.dataLength) + '...'
 												+ '</span>'
 												+ pill;


### PR DESCRIPTION
As part of the text is hidden behind ellipsis (...), we should at least add a title so that a user hovering the item can see the full text that was supposed to be displayed