### PR TITLE
Fix panes container visibility issue with ajax reload

### DIFF
--- a/src/searchPanes.ts
+++ b/src/searchPanes.ts
@@ -477,6 +477,7 @@ export default class SearchPanes {
 		// If a pane is to be displayed then attach the normal pane output
 		for (let pane of this.s.panes) {
 			if (pane.s.displayed === true) {
+				this.dom.container.removeClass(this.classes.hide);
 				return;
 			}
 		}


### PR DESCRIPTION
Make sure to remove the hidden css class from the panes container when using ajax reload and some panes are available to display.