### PR TITLE
Fix search pane sorting on array valued column

### DIFF
--- a/src/searchPane.ts
+++ b/src/searchPane.ts
@@ -588,7 +588,7 @@ export default class SearchPane {
 				display = display.toArray();
 			}
 
-			if (filter.length === display.length) {
+			if (filter.length === display.length && filter.length === sort.length) {
 				for (let i: number = 0; i < filter.length; i++) {
 					// If we haven't seen this row before add it
 					if (!bins[filter[i]]) {
@@ -596,7 +596,7 @@ export default class SearchPane {
 						arrayFilter.push({
 							display: display[i],
 							filter: filter[i],
-							sort,
+							sort: sort[i],
 							type
 						});
 					}
@@ -609,7 +609,7 @@ export default class SearchPane {
 				return;
 			}
 			else {
-				throw new Error('display and filter not the same length');
+				throw new Error('display, filter and sort are not the same length');
 			}
 		}
 		// If the values were affected by othogonal data and are not an array then check if it is already present

--- a/src/searchPane.ts
+++ b/src/searchPane.ts
@@ -586,6 +586,7 @@ export default class SearchPane {
 			if (filter instanceof DataTable.Api) {
 				filter = filter.toArray();
 				display = display.toArray();
+				sort = sort.toArray();
 			}
 
 			if (filter.length === display.length && filter.length === sort.length) {


### PR DESCRIPTION
I have noticed an issue where alphabetically sorting one of the filter lists for a particular column if that column returns array valued data. 
It is visible in the following example when you attempt to sort the Permissions filter alphabetically:
https://datatables.net/extensions/searchpanes/examples/advanced/renderSearchArrays.html

If you sort the search pane for Permissions, you should see that it only looks like it is sorting the examples. Desktop and Website do not move at all. This is because Desktop and Web-site appear in the same row of the original data table and the sorting forgot to account for that. 
Note that Printer does move but that is only because it was first encountered in its own row earlier in the data table.

I implemented this change on a project of mine and this fixed the issue but please review and test yourselves to confirm this.

I am not 100% sure about merging into master, but I did not see anything in the ReadMe and I saw no develop branch. If I am doing something wrong, please let me know and I will try to fix it.