### PR TITLE
Updated it from "invert();" to "invert(1);" to ensure proper inversion.

### DIFF
--- a/css/searchPanes.bootstrap5.scss
+++ b/css/searchPanes.bootstrap5.scss
@@ -105,15 +105,15 @@ div.dt-button-collection{
 html[data-bs-theme="dark"] {
 	div.dtsp-topRow {
         button.dtsp-searchIcon span {
-            filter: #{"invert()"};
+            filter: invert(1);
         }
 	
 		button.dtsp-nameButton span {
-			filter: #{"invert()"};
+			filter: invert(1);
 		}
 	
 		button.dtsp-countButton span {
-			filter: #{"invert()"};
+			filter: invert(1);
 		}
 
 		input.dtsp-paneInputButton,

--- a/css/searchPanes.dataTables.scss
+++ b/css/searchPanes.dataTables.scss
@@ -106,16 +106,16 @@ html.dark {
 	div.dtsp-topRow {
 		div.dtsp-subRow1 {
 			button.dtsp-searchIcon span {
-				filter: #{"invert()"};
+				filter: invert(1);
 			}
 		}
 	
 		button.dtsp-nameButton span {
-			filter: #{"invert()"};
+			filter: invert(1);
 		}
 	
 		button.dtsp-countButton span {
-			filter: #{"invert()"};
+			filter: invert(1);
 		}
 
 		input.dtsp-paneInputButton,

--- a/css/searchPanes.foundation.scss
+++ b/css/searchPanes.foundation.scss
@@ -60,15 +60,15 @@ div.dtsp-searchPane {
         }
 
         button.dtsp-searchIcon span {
-            filter: #{"invert()"};
+            filter: invert(1);
         }
 	
 		button.dtsp-nameButton span {
-			filter: #{"invert()"};
+			filter: invert(1);
 		}
 	
 		button.dtsp-countButton span {
-			filter: #{"invert()"};
+			filter: invert(1);
 		}
     }
 


### PR DESCRIPTION
Proposed Changes:

In this PR, I've made the following changes:

Updated the filter property in the CSS code to use invert(1) instead of invert() for proper inversion in dark mode.

https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/invert#parameters
#css #dark-mode #filter-property