### PR TITLE
Update types.d.ts to include full language option

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6,6 +6,7 @@
 
 import DataTables, {Api} from 'datatables.net';
 import * as paneType from './paneType';
+import * as paneTypes from './paneTypes';
 
 export default DataTables;
 
@@ -75,7 +76,7 @@ declare module 'datatables.net' {
 
 interface ConfigSearchPanes extends DeepPartial<paneType.IDefaults> {}
 
-interface ConfigSearchPanesLanguage extends DeepPartial<paneType.IDefaults['i18n']> {}
+interface ConfigSearchPanesLanguage extends DeepPartial<paneTypes.IDefaults['i18n']> {}
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *


### PR DESCRIPTION
Currently the typescript doesn't allow you to set all of the language options for search panes. This fixes it by using the right copy of i18n.